### PR TITLE
Fixing an issue with the plotter

### DIFF
--- a/plot_mVSpT.py
+++ b/plot_mVSpT.py
@@ -62,8 +62,8 @@ eosDir='root://cmsxrootd.fnal.gov//store/user/ddicroce/test'
 
 files_ = []
 firstfile = True
-#filelist = '/uscms/home/ddicroce/nobackup/TauClassifier/CMSSW_10_2_20_UL/src/MLAnalyzer/list_HTauTau_biased.txt'
-filelist= 'testlist_sim_Jul14.txt'
+filelist = '/uscms/home/ddicroce/nobackup/TauClassifier/CMSSW_10_2_20_UL/src/MLAnalyzer/list_HTauTau_biased.txt'
+#filelist= 'testlist_sim_Jul14.txt'
 with open(filelist) as list_:
     content = list_.readlines()
 paths = [x.strip() for x in content] 

--- a/plot_mVSpT.py
+++ b/plot_mVSpT.py
@@ -106,7 +106,7 @@ print(binmax)
 histos['mVSpT_ratio'] = histos['mVSpT'].Clone('mVSpT_ratio')
 for iBinX in range(histos['mVSpT_ratio'].GetNbinsX()):
   for iBinY in range(histos['mVSpT_ratio'].GetNbinsY()):
-    if (histos['mVSpT'].GetBinContent(iBinX+1,iBinY+1) == 0): continue
+    if (histos['mVSpT'].GetBinContent(iBinX+1,iBinY+1) == 0): continue   #Avoids division by 0, in the case that the bin content was 0
     histos['mVSpT_ratio'].SetBinContent(iBinX+1, iBinY+1, ((1/binmax)*(histos['mVSpT'].GetBinContent(iBinX+1,iBinY+1))) )
     histos['mVSpT_inverted'].SetBinContent(iBinX+1, iBinY+1, (1/binmax)*(binint/histos['mVSpT'].GetBinContent(iBinX+1,iBinY+1)))
 

--- a/plot_mVSpT.py
+++ b/plot_mVSpT.py
@@ -62,7 +62,8 @@ eosDir='root://cmsxrootd.fnal.gov//store/user/ddicroce/test'
 
 files_ = []
 firstfile = True
-filelist = '/uscms/home/ddicroce/nobackup/TauClassifier/CMSSW_10_2_20_UL/src/MLAnalyzer/list_HTauTau_biased.txt'
+#filelist = '/uscms/home/ddicroce/nobackup/TauClassifier/CMSSW_10_2_20_UL/src/MLAnalyzer/list_HTauTau_biased.txt'
+filelist= 'testlist_sim_Jul14.txt'
 with open(filelist) as list_:
     content = list_.readlines()
 paths = [x.strip() for x in content] 
@@ -105,6 +106,7 @@ print(binmax)
 histos['mVSpT_ratio'] = histos['mVSpT'].Clone('mVSpT_ratio')
 for iBinX in range(histos['mVSpT_ratio'].GetNbinsX()):
   for iBinY in range(histos['mVSpT_ratio'].GetNbinsY()):
+    if (histos['mVSpT'].GetBinContent(iBinX+1,iBinY+1) == 0): continue
     histos['mVSpT_ratio'].SetBinContent(iBinX+1, iBinY+1, ((1/binmax)*(histos['mVSpT'].GetBinContent(iBinX+1,iBinY+1))) )
     histos['mVSpT_inverted'].SetBinContent(iBinX+1, iBinY+1, (1/binmax)*(binint/histos['mVSpT'].GetBinContent(iBinX+1,iBinY+1)))
 
@@ -116,6 +118,7 @@ for iBinX in range(histos['mass'].GetNbinsX()):
   if (massmax < massint/histos['mass'].GetBinContent(iBinX+1)): 
     massmax = massint/histos['mass'].GetBinContent(iBinX+1)
 for iBinX in range(histos['mass_inverted'].GetNbinsX()):
+  if (histos['mass'].GetBinContent(iBinX+1) == 0): continue  #Avoids division by 0, in the case that the bin content was 0
   histos['mass_inverted'].SetBinContent(iBinX+1, (1/massmax)*(massint/histos['mass'].GetBinContent(iBinX+1)))
 
 histos['pt_inverted'] = histos['pt'].Clone('pt_inverted')
@@ -126,6 +129,7 @@ for iBinX in range(histos['pt'].GetNbinsX()):
   if (ptmax < ptint/histos['pt'].GetBinContent(iBinX+1)):
     ptmax = ptint/histos['pt'].GetBinContent(iBinX+1)
 for iBinX in range(histos['pt_inverted'].GetNbinsX()):
+  if (histos['pt'].GetBinContent(iBinX+1) == 0): continue  #Avoids division by 0, in the case that the bin content was 0
   histos['pt_inverted'].SetBinContent(iBinX+1, (1/ptmax)*(ptint/histos['pt'].GetBinContent(iBinX+1)))
   
 print(binx)

--- a/plot_mVSpT_unbiased.py
+++ b/plot_mVSpT_unbiased.py
@@ -105,6 +105,7 @@ print(binmax)
 histos['mVSpT_ratio'] = histos['mVSpT'].Clone('mVSpT_ratio')
 for iBinX in range(histos['mVSpT_ratio'].GetNbinsX()):
   for iBinY in range(histos['mVSpT_ratio'].GetNbinsY()):
+    if (histos['mVSpT'].GetBinContent(iBinX+1,iBinY+1) == 0): continue   #Avoids division by 0, in the case that the bin content was 0
     histos['mVSpT_ratio'].SetBinContent(iBinX+1, iBinY+1, ((1/binmax)*(histos['mVSpT'].GetBinContent(iBinX+1,iBinY+1))) )
     histos['mVSpT_inverted'].SetBinContent(iBinX+1, iBinY+1, (1/binmax)*(binint/histos['mVSpT'].GetBinContent(iBinX+1,iBinY+1)))
 
@@ -116,6 +117,7 @@ for iBinX in range(histos['mass'].GetNbinsX()):
   if (massmax < massint/histos['mass'].GetBinContent(iBinX+1)): 
     massmax = massint/histos['mass'].GetBinContent(iBinX+1)
 for iBinX in range(histos['mass_inverted'].GetNbinsX()):
+  if (histos['mass'].GetBinContent(iBinX+1) == 0): continue  #Avoids division by 0, in the case that the bin content was 0
   histos['mass_inverted'].SetBinContent(iBinX+1, (1/massmax)*(massint/histos['mass'].GetBinContent(iBinX+1)))
 
 histos['pt_inverted'] = histos['pt'].Clone('pt_inverted')
@@ -126,6 +128,7 @@ for iBinX in range(histos['pt'].GetNbinsX()):
   if (ptmax < ptint/histos['pt'].GetBinContent(iBinX+1)):
     ptmax = ptint/histos['pt'].GetBinContent(iBinX+1)
 for iBinX in range(histos['pt_inverted'].GetNbinsX()):
+  if (histos['pt'].GetBinContent(iBinX+1) == 0): continue  #Avoids division by 0, in the case that the bin content was 0
   histos['pt_inverted'].SetBinContent(iBinX+1, (1/ptmax)*(ptint/histos['pt'].GetBinContent(iBinX+1)))
   
 print(binx)


### PR DESCRIPTION
The plotter, in its calculations of the inverted values, does not account for division by 0, such as when a bin has 0 elements. This is not a problem when working with large samples, but when testing on small samples it creates problems. I've added a few lines to skip these cases.